### PR TITLE
Update to latest Netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-neptune-sigv4-signer</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.1</version>
+    <version>2.1.2</version>
 
     <name>amazon-neptune-sigv4-signer</name>
     <description>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.48.Final</version>
+            <version>4.1.59.Final</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Previous versions are affected by CVE-2021-21290: https://nvd.nist.gov/vuln/detail/CVE-2021-21290

*Issue #, if available:*

*Description of changes:*
Updated to latest version of netty. Also updated revision for main assembly version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
