### PR TITLE
reuse the same credentials object

### DIFF
--- a/src/main/java/com/amazonaws/neptune/auth/NeptuneSigV4SignerBase.java
+++ b/src/main/java/com/amazonaws/neptune/auth/NeptuneSigV4SignerBase.java
@@ -18,6 +18,7 @@ package com.amazonaws.neptune.auth;
 import com.amazonaws.DefaultRequest;
 import com.amazonaws.SignableRequest;
 import com.amazonaws.auth.AWS4Signer;
+import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.http.HttpMethodName;
@@ -157,12 +158,13 @@ public abstract class NeptuneSigV4SignerBase<T> implements NeptuneSigV4Signer<T>
 
             // 2. Sign the AWS SDK signable request (which internally adds some HTTP headers)
             //    => generic, using the AWS SDK signer
-            aws4Signer.sign(awsSignableRequest, awsCredentialsProvider.getCredentials());
+            final AWSCredentials credentials = awsCredentialsProvider.getCredentials();
+            aws4Signer.sign(awsSignableRequest, credentials);
 
             // extract session token if temporary credentials are provided
             String sessionToken = "";
-            if ((awsCredentialsProvider.getCredentials() instanceof BasicSessionCredentials)) {
-                sessionToken = ((BasicSessionCredentials) awsCredentialsProvider.getCredentials()).getSessionToken();
+            if ((credentials instanceof BasicSessionCredentials)) {
+                sessionToken = ((BasicSessionCredentials) credentials).getSessionToken();
             }
 
             final NeptuneSigV4Signature signature =


### PR DESCRIPTION
*Issue #, if available:* Using the `NeptuneApacheHttpSigV4Signer.signRequest()` in a Kubernetes deployment that is using [kiam](https://github.com/uswitch/kiam), and the `DefaultAWSCredentialsProviderChain` as a provider, we have noticed that connecting to Neptune we receive the message: 

> AccessDenied  _The security token included in the request is invalid_. 

We have verified that the signed request contains:
```
Authorization: AWS4-HMAC-SHA256 Credential=ASIAXXX/...  
X-Amz-Security-Token: IQoJb3JpZ2luXXXX...
```
but the AssumeRole call in CloudTrail shows that principal in the `Authorization` header doesn't match the `X-Amz-Security-Token` value. In other words, it appears that calling getCredentials() more than once can return different credentials objects 

*Description of changes:*
Call getCredentials() only once, and store the result in a variable, to ensure that the AWS AccessKey and Session Token are consistent.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
