### PR TITLE
Updated library to use AWS Java SDK v2.25.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-neptune-sigv4-signer</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>amazon-neptune-sigv4-signer</name>
     <description>
@@ -65,8 +65,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -81,10 +81,21 @@
             <version>4.5.13</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-core</artifactId>
-            <version>1.12.241</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth-aws</artifactId>
+            <version>2.25.13</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>2.25.13</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.25.13</version>
+        </dependency>
+
 
         <!-- Test -->
         <dependency>

--- a/src/main/java/com/amazonaws/neptune/auth/NeptuneApacheHttpSigV4Signer.java
+++ b/src/main/java/com/amazonaws/neptune/auth/NeptuneApacheHttpSigV4Signer.java
@@ -15,8 +15,8 @@
 
 package com.amazonaws.neptune.auth;
 
-import com.amazonaws.SignableRequest;
-import com.amazonaws.auth.AWSCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
@@ -30,13 +30,14 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.amazonaws.auth.internal.SignerConstants.AUTHORIZATION;
-import static com.amazonaws.auth.internal.SignerConstants.HOST;
-import static com.amazonaws.auth.internal.SignerConstants.X_AMZ_DATE;
-import static com.amazonaws.auth.internal.SignerConstants.X_AMZ_SECURITY_TOKEN;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.AUTHORIZATION;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.HOST;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_DATE;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_SECURITY_TOKEN;
 
 /**
  * Signer for HTTP requests made via Apache Commons {@link HttpUriRequest}s.
@@ -62,14 +63,14 @@ public class NeptuneApacheHttpSigV4Signer extends NeptuneSigV4SignerBase<HttpUri
      * @throws NeptuneSigV4SignerException in case initialization fails
      */
     public NeptuneApacheHttpSigV4Signer(
-            final String regionName, final AWSCredentialsProvider awsCredentialsProvider)
+            final String regionName, final AwsCredentialsProvider awsCredentialsProvider)
             throws NeptuneSigV4SignerException {
 
         super(regionName, awsCredentialsProvider);
     }
 
     @Override
-    protected SignableRequest<?> toSignableRequest(final HttpUriRequest request)
+    protected SdkHttpFullRequest toSignableRequest(final HttpUriRequest request)
             throws NeptuneSigV4SignerException {
 
         // make sure the request is not null and contains the minimal required set of information
@@ -79,11 +80,12 @@ public class NeptuneApacheHttpSigV4Signer extends NeptuneSigV4SignerBase<HttpUri
 
         // convert the headers to the internal API format
         final Header[] headers = request.getAllHeaders();
-        final Map<String, String> headersInternal = new HashMap<>();
+
+        final Map<String, List<String>> headersInternal = new HashMap<>();
         for (final Header header : headers) {
             // Skip adding the Host header as the signing process will add one.
             if (!header.getName().equalsIgnoreCase(HOST)) {
-                headersInternal.put(header.getName(), header.getValue());
+                headersInternal.put(header.getName(), Arrays.asList(header.getValue()));
             }
         }
 

--- a/src/test/java/com/amazonaws/neptune/auth/NeptuneApacheHttpSigV4SignerTest.java
+++ b/src/test/java/com/amazonaws/neptune/auth/NeptuneApacheHttpSigV4SignerTest.java
@@ -15,7 +15,7 @@
 
 package com.amazonaws.neptune.auth;
 
-import com.amazonaws.SignableRequest;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.client.methods.HttpGet;
@@ -57,17 +57,17 @@ public class NeptuneApacheHttpSigV4SignerTest extends NeptuneSigV4SignerAbstract
         final HttpRequestWrapper wrapper = HttpRequestWrapper.wrap(request, httpHost);
 
         // call
-        final SignableRequest signableRequest = signer.toSignableRequest(wrapper);
+        final SdkHttpFullRequest signableRequest = signer.toSignableRequest(wrapper);
 
         // verify
-        Map<String, List<String>> headers = signableRequest.getHeaders();
+        Map<String, List<String>> headers = signableRequest.headers();
         assertEquals("Headers host size should be 2", 2, headers.size());
-        assertEquals("Non host header should be retained", HEADER_ONE_VALUE, headers.get(HEADER_ONE_NAME));
-        assertEquals("Non host header should be retained", HEADER_TWO_VALUE, headers.get(HEADER_TWO_NAME));
-        assertEquals("Endpoint returned is not as expected", URI.create(TEST_ENDPOINT_URI),
-                signableRequest.getEndpoint());
+        assertEquals("Non host header should be retained", Arrays.asList(HEADER_ONE_VALUE), headers.get(HEADER_ONE_NAME));
+        assertEquals("Non host header should be retained", Arrays.asList(HEADER_TWO_VALUE), headers.get(HEADER_TWO_NAME));
+        assertEquals("Endpoint returned is not as expected", URI.create(TEST_FULL_URI),
+                signableRequest.getUri());
         assertEquals("Resource returned is not as expected", TEST_REQUEST_PATH,
-                signableRequest.getResourcePath());
+                signableRequest.encodedPath());
     }
 
     @Override


### PR DESCRIPTION
Issue #, if available: #23

Description of changes:
- Updated POM file to use Java 17.
- Changed AWS Java SDK version from 1.12.241 to 2.25.13
- SignableRequest deprecated in SDK v1.  Changed to use SdkHttpFullRequest.
    - Header datatype change from the `Map<String, String>` format in SignableRequest to `Map<String, List<String>>` format in SdkHttpFullRequest.  This required changes in many of the tests to encapsulate header values into a list.
    - Current library assumes one value per header (as this was the only possibility with SignableRequest).  We can change this at a later date to support multiple values per header (with SdkHttpFullRequest) by changing the code on 177-180 in NeptuneSigV4SignerBase.java.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
