### PR TITLE
Add new constructors in Signer classes to use java v1 credentials and support to use different signing name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
             <version>2.25.13</version>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>1.12.772</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>auth</artifactId>
             <version>2.25.13</version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-neptune-sigv4-signer</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.2</version>
+    <version>3.0.1</version>
 
     <name>amazon-neptune-sigv4-signer</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-neptune-sigv4-signer</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.2</version>
 
     <name>amazon-neptune-sigv4-signer</name>
     <description>

--- a/src/main/java/com/amazonaws/neptune/auth/NeptuneApacheHttpSigV4Signer.java
+++ b/src/main/java/com/amazonaws/neptune/auth/NeptuneApacheHttpSigV4Signer.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.neptune.auth;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import org.apache.http.Header;
@@ -59,14 +60,57 @@ public class NeptuneApacheHttpSigV4Signer extends NeptuneSigV4SignerBase<HttpUri
      * Create a V4 Signer for Apache Commons HTTP requests.
      *
      * @param regionName             name of the region for which the request is signed
+     * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
+     * @throws NeptuneSigV4SignerException in case initialization fails
+     */
+    public NeptuneApacheHttpSigV4Signer(final String regionName,
+                                        final AWSCredentialsProvider v1AwsCredentialProvider)
+            throws NeptuneSigV4SignerException {
+
+        super(regionName, v1AwsCredentialProvider);
+    }
+
+    /**
+     * Create a V4 Signer for Apache Commons HTTP requests.
+     *
+     * @param regionName             name of the region for which the request is signed
+     * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
+     * @param serviceName            name of the service name used to sign the requests. Defaults to neptune-db
+     * @throws NeptuneSigV4SignerException in case initialization fails
+     */
+    public NeptuneApacheHttpSigV4Signer(final String regionName,
+                                        final AWSCredentialsProvider v1AwsCredentialProvider,
+                                        final String serviceName) throws NeptuneSigV4SignerException {
+
+        super(regionName, v1AwsCredentialProvider, serviceName);
+    }
+
+    /**
+     * Create a V4 Signer for Apache Commons HTTP requests.
+     *
+     * @param regionName             name of the region for which the request is signed
      * @param awsCredentialsProvider the provider offering access to the credentials used for signing the request
      * @throws NeptuneSigV4SignerException in case initialization fails
      */
-    public NeptuneApacheHttpSigV4Signer(
-            final String regionName, final AwsCredentialsProvider awsCredentialsProvider)
-            throws NeptuneSigV4SignerException {
+    public NeptuneApacheHttpSigV4Signer(final String regionName,
+                                        final AwsCredentialsProvider awsCredentialsProvider) throws NeptuneSigV4SignerException {
 
         super(regionName, awsCredentialsProvider);
+    }
+
+    /**
+     * Create a V4 Signer for Apache Commons HTTP requests.
+     *
+     * @param regionName             name of the region for which the request is signed
+     * @param awsCredentialsProvider the provider offering access to the credentials used for signing the request
+     * @param serviceName            name of the service name used to sign the requests. Defaults to neptune-db
+     * @throws NeptuneSigV4SignerException in case initialization fails
+     */
+    public NeptuneApacheHttpSigV4Signer(final String regionName,
+                                        final AwsCredentialsProvider awsCredentialsProvider,
+                                        final String serviceName) throws NeptuneSigV4SignerException {
+
+        super(regionName, awsCredentialsProvider, serviceName);
     }
 
     @Override

--- a/src/main/java/com/amazonaws/neptune/auth/NeptuneNettyHttpSigV4Signer.java
+++ b/src/main/java/com/amazonaws/neptune/auth/NeptuneNettyHttpSigV4Signer.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.neptune.auth;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.utils.StringUtils;
@@ -48,13 +49,52 @@ public class NeptuneNettyHttpSigV4Signer extends NeptuneSigV4SignerBase<FullHttp
      * Create a V4 Signer for Netty HTTP requests.
      *
      * @param regionName             name of the region for which the request is signed
+     * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
+     * @throws NeptuneSigV4SignerException in case initialization fails
+     */
+    public NeptuneNettyHttpSigV4Signer(final String regionName,
+                                       final AWSCredentialsProvider v1AwsCredentialProvider) throws NeptuneSigV4SignerException {
+        super(regionName, v1AwsCredentialProvider);
+    }
+
+    /**
+     * Create a V4 Signer for Netty HTTP requests.
+     *
+     * @param regionName             name of the region for which the request is signed
+     * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
+     * @param serviceName            name of the service name used to sign the requests. Defaults to neptune-db
+     * @throws NeptuneSigV4SignerException in case initialization fails
+     */
+    public NeptuneNettyHttpSigV4Signer(final String regionName,
+                                       final AWSCredentialsProvider v1AwsCredentialProvider,
+                                       final String serviceName) throws NeptuneSigV4SignerException {
+        super(regionName, v1AwsCredentialProvider, serviceName);
+    }
+
+    /**
+     * Create a V4 Signer for Netty HTTP requests.
+     *
+     * @param regionName             name of the region for which the request is signed
      * @param awsCredentialsProvider the provider offering access to the credentials used for signing the request
      * @throws NeptuneSigV4SignerException in case initialization fails
      */
-    public NeptuneNettyHttpSigV4Signer(
-            final String regionName, final AwsCredentialsProvider awsCredentialsProvider)
-            throws NeptuneSigV4SignerException {
+    public NeptuneNettyHttpSigV4Signer(final String regionName,
+                                       final AwsCredentialsProvider awsCredentialsProvider) throws NeptuneSigV4SignerException {
         super(regionName, awsCredentialsProvider);
+    }
+
+    /**
+     * Create a V4 Signer for Netty HTTP requests.
+     *
+     * @param regionName             name of the region for which the request is signed
+     * @param awsCredentialsProvider the provider offering access to the credentials used for signing the request
+     * @param serviceName            name of the service name used to sign the requests. Defaults to neptune-db
+     * @throws NeptuneSigV4SignerException in case initialization fails
+     */
+    public NeptuneNettyHttpSigV4Signer(final String regionName,
+                                       final AwsCredentialsProvider awsCredentialsProvider,
+                                       final String serviceName) throws NeptuneSigV4SignerException {
+        super(regionName, awsCredentialsProvider, serviceName);
     }
 
     @Override

--- a/src/main/java/com/amazonaws/neptune/auth/NeptuneRequestMetadataSigV4Signer.java
+++ b/src/main/java/com/amazonaws/neptune/auth/NeptuneRequestMetadataSigV4Signer.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.neptune.auth;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
@@ -48,6 +49,33 @@ import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerCo
  * </ul>
  */
 public class NeptuneRequestMetadataSigV4Signer extends NeptuneSigV4SignerBase<RequestMetadata> {
+
+    /**
+     * Create a V4 Signer for {@link RequestMetadata}.
+     *
+     * @param regionName             name of the region for which the request is signed
+     * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
+     * @throws NeptuneSigV4SignerException in case initialization fails
+     */
+    public NeptuneRequestMetadataSigV4Signer(final String regionName,
+                                             final AWSCredentialsProvider v1AwsCredentialProvider) throws NeptuneSigV4SignerException {
+        super(regionName, v1AwsCredentialProvider);
+    }
+
+    /**
+     * Create a V4 Signer for {@link RequestMetadata}.
+     *
+     * @param regionName             name of the region for which the request is signed
+     * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
+     * @param serviceName            name of the service name used to sign the requests. Defaults to neptune-db
+     * @throws NeptuneSigV4SignerException in case initialization fails
+     */
+    public NeptuneRequestMetadataSigV4Signer(final String regionName,
+                                             final AWSCredentialsProvider v1AwsCredentialProvider,
+                                             final String serviceName) throws NeptuneSigV4SignerException {
+        super(regionName, v1AwsCredentialProvider, serviceName);
+    }
+
     /**
      * Create a V4 Signer for {@link RequestMetadata}.
      *
@@ -55,11 +83,23 @@ public class NeptuneRequestMetadataSigV4Signer extends NeptuneSigV4SignerBase<Re
      * @param awsCredentialsProvider the provider offering access to the credentials used for signing the request
      * @throws NeptuneSigV4SignerException in case initialization fails
      */
-    public NeptuneRequestMetadataSigV4Signer(
-            final String regionName, final AwsCredentialsProvider awsCredentialsProvider)
-            throws NeptuneSigV4SignerException {
-
+    public NeptuneRequestMetadataSigV4Signer(final String regionName,
+                                             final AwsCredentialsProvider awsCredentialsProvider) throws NeptuneSigV4SignerException {
         super(regionName, awsCredentialsProvider);
+    }
+
+    /**
+     * Create a V4 Signer for {@link RequestMetadata}.
+     *
+     * @param regionName             name of the region for which the request is signed
+     * @param awsCredentialsProvider the provider offering access to the credentials used for signing the request
+     * @param serviceName            name of the service name used to sign the requests. Defaults to neptune-db
+     * @throws NeptuneSigV4SignerException in case initialization fails
+     */
+    public NeptuneRequestMetadataSigV4Signer(final String regionName,
+                                             final AwsCredentialsProvider awsCredentialsProvider,
+                                             final String serviceName) throws NeptuneSigV4SignerException {
+        super(regionName, awsCredentialsProvider, serviceName);
     }
 
     /**

--- a/src/main/java/com/amazonaws/neptune/auth/credentials/V1toV2CredentialsProvider.java
+++ b/src/main/java/com/amazonaws/neptune/auth/credentials/V1toV2CredentialsProvider.java
@@ -1,0 +1,40 @@
+package com.amazonaws.neptune.auth.credentials;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSSessionCredentials;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+
+public class V1toV2CredentialsProvider implements AwsCredentialsProvider {
+    private final AWSCredentialsProvider v1CredentialsProvider;
+
+    public static AwsCredentialsProvider create(final AWSCredentialsProvider v1CredentialsProvider) {
+        return new V1toV2CredentialsProvider(v1CredentialsProvider);
+    }
+
+    private V1toV2CredentialsProvider(final AWSCredentialsProvider v1CredentialsProvider) {
+        this.v1CredentialsProvider = v1CredentialsProvider;
+    }
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+        final AWSCredentials v1Credentials = this.v1CredentialsProvider.getCredentials();
+
+        if (v1Credentials instanceof AnonymousAWSCredentials) {
+            return AnonymousCredentialsProvider.create().resolveCredentials();
+        } else if (v1Credentials instanceof AWSSessionCredentials) {
+            return AwsSessionCredentials.builder()
+                    .accessKeyId(v1Credentials.getAWSAccessKeyId())
+                    .secretAccessKey(v1Credentials.getAWSSecretKey())
+                    .sessionToken(((AWSSessionCredentials) v1Credentials).getSessionToken())
+                    .build();
+        } else {
+            return AwsBasicCredentials.create(v1Credentials.getAWSAccessKeyId(), v1Credentials.getAWSSecretKey());
+        }
+    }
+}

--- a/src/test/java/com/amazonaws/neptune/auth/credentials/V1toV2CredentialsProviderTest.java
+++ b/src/test/java/com/amazonaws/neptune/auth/credentials/V1toV2CredentialsProviderTest.java
@@ -1,0 +1,74 @@
+package com.amazonaws.neptune.auth.credentials;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSSessionCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+
+public class V1toV2CredentialsProviderTest {
+
+    @Test
+    public void testConversionOfCredentials() {
+        final AWSCredentials sessionCredentials = new BasicAWSCredentials("accessKey", "SecretKey");
+        final AWSCredentialsProvider v1CredentialProvider = buildV1CredentialsProvider(sessionCredentials);
+        final AwsCredentialsProvider v2CredentialsProvider = V1toV2CredentialsProvider.create(v1CredentialProvider);
+
+        // Assert
+        assertV2Credentials(v2CredentialsProvider, sessionCredentials);
+    }
+
+    @Test
+    public void testConversionOfSessionCredentials() {
+        final AWSCredentials sessionCredentials = new BasicSessionCredentials("accessKey", "SecretKey", "sessionToken");
+        final AWSCredentialsProvider v1CredentialProvider = buildV1CredentialsProvider(sessionCredentials);
+        final AwsCredentialsProvider v2CredentialsProvider = V1toV2CredentialsProvider.create(v1CredentialProvider);
+
+        // Assert
+        assertV2Credentials(v2CredentialsProvider, sessionCredentials);
+    }
+
+    @Test
+    public void testConversionOfAnonCredentials() {
+        final AWSCredentials anonV1Credentials = new AnonymousAWSCredentials();
+        final AWSCredentialsProvider v1CredentialProvider = buildV1CredentialsProvider(anonV1Credentials);
+        final AwsCredentialsProvider v2CredentialsProvider = V1toV2CredentialsProvider.create(v1CredentialProvider);
+
+        assertNotNull(v2CredentialsProvider);
+        final AwsCredentials v2Credentials = v2CredentialsProvider.resolveCredentials();
+        assertNotNull(v2Credentials);
+        // AccessKey and secret key will be null for Anon Credentials
+        assertNull(v2Credentials.accessKeyId());
+        assertNull(v2Credentials.secretAccessKey());
+    }
+
+    private void assertV2Credentials(final AwsCredentialsProvider v2CredentialsProvider,
+                                     final AWSCredentials expectedCredentials) {
+        assertNotNull(v2CredentialsProvider);
+        final AwsCredentials v2Credentials = v2CredentialsProvider.resolveCredentials();
+        assertNotNull(v2Credentials);
+        assertEquals(v2Credentials.accessKeyId(), expectedCredentials.getAWSAccessKeyId());
+        assertEquals(v2Credentials.secretAccessKey(), expectedCredentials.getAWSSecretKey());
+        if (expectedCredentials instanceof AWSSessionCredentials) {
+            assertTrue(v2Credentials instanceof AwsSessionCredentialsIdentity);
+            assertEquals(((AwsSessionCredentialsIdentity)v2Credentials).sessionToken(),
+                    ((AWSSessionCredentials)expectedCredentials).getSessionToken());
+        }
+    }
+
+    private static AWSCredentialsProvider buildV1CredentialsProvider(final AWSCredentials credentials) {
+        return new AWSStaticCredentialsProvider(credentials);
+    }
+}

--- a/src/test/java/com/amazonaws/neptune/auth/credentials/V1toV2CredentialsProviderTest.java
+++ b/src/test/java/com/amazonaws/neptune/auth/credentials/V1toV2CredentialsProviderTest.java
@@ -22,12 +22,12 @@ public class V1toV2CredentialsProviderTest {
 
     @Test
     public void testConversionOfCredentials() {
-        final AWSCredentials sessionCredentials = new BasicAWSCredentials("accessKey", "SecretKey");
-        final AWSCredentialsProvider v1CredentialProvider = buildV1CredentialsProvider(sessionCredentials);
+        final AWSCredentials credentials = new BasicAWSCredentials("accessKey", "SecretKey");
+        final AWSCredentialsProvider v1CredentialProvider = buildV1CredentialsProvider(credentials);
         final AwsCredentialsProvider v2CredentialsProvider = V1toV2CredentialsProvider.create(v1CredentialProvider);
 
         // Assert
-        assertV2Credentials(v2CredentialsProvider, sessionCredentials);
+        assertV2Credentials(v2CredentialsProvider, credentials);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Adds new constructor to use java sdk v1 version of AWSCredentials to sign the requests. Defaults to using Java SDK V2 credentials
* Adds provision to use service name used to signing requests. Defaults to neptune-db if not provided


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
