### PR TITLE
Deprecate SDK v1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,29 @@ A library for sending AWS Signature Version 4 signed requests over HTTP to [Amaz
 1. [NeptuneApacheHttpSigV4Signer.java](https://github.com/aws/amazon-neptune-sigv4-signer/blob/master/src/main/java/com/amazonaws/neptune/auth/NeptuneApacheHttpSigV4Signer.java) - provides an implementation for signing Apache Http Requests.
 2. [NeptuneNettyHttpSigV4Signer.java](https://github.com/aws/amazon-neptune-sigv4-signer/blob/master/src/main/java/com/amazonaws/neptune/auth/NeptuneNettyHttpSigV4Signer.java) - provides an implementation for signing Netty Http requests
 3. [NeptuneRequestMetadataSigV4Signer.java](https://github.com/aws/amazon-neptune-sigv4-signer/blob/master/src/main/java/com/amazonaws/neptune/auth/NeptuneRequestMetadataSigV4Signer.java) - provides an implementation for a generic Request object RequestMetadata. A user of this class can convert their native HttpRequest into a RequestMetadata object and pass it to this class to create the signature.
- 
+
+## ⚠️ SDK v1 Deprecation Notice
+
+As of version 4.1.0, AWS SDK v1 support is **deprecated** and will be removed in a future major version.
+
+**What changed:**
+- The `aws-java-sdk-core` dependency is now `<optional>true</optional>` — it is no longer pulled transitively. If you still use SDK v1 constructors, you must explicitly declare `aws-java-sdk-core` in your own `pom.xml`.
+- All constructors accepting `com.amazonaws.auth.AWSCredentialsProvider` (SDK v1) are deprecated.
+- The `V1toV2CredentialsProvider` adapter class is deprecated.
+
+**Recommended usage (SDK v2):**
+
+```java
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import com.amazonaws.neptune.auth.NeptuneNettyHttpSigV4Signer;
+
+NeptuneNettyHttpSigV4Signer signer = new NeptuneNettyHttpSigV4Signer(
+    "us-east-1",
+    DefaultCredentialsProvider.create());
+```
+
+## Usage Examples
+
 For examples of usage of this library refer to:
 
 1. [Connecting to Neptune Using Java and Gremlin with Signature Version 4 Signing](https://docs.aws.amazon.com/neptune/latest/userguide/iam-auth-connecting-gremlin-java.html)

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-neptune-sigv4-signer</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
 
     <name>amazon-neptune-sigv4-signer</name>
     <description>
@@ -94,6 +94,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
             <version>1.12.772</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/src/main/java/com/amazonaws/neptune/auth/NeptuneApacheHttpSigV4Signer.java
+++ b/src/main/java/com/amazonaws/neptune/auth/NeptuneApacheHttpSigV4Signer.java
@@ -62,7 +62,10 @@ public class NeptuneApacheHttpSigV4Signer extends NeptuneSigV4SignerBase<HttpUri
      * @param regionName             name of the region for which the request is signed
      * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
      * @throws NeptuneSigV4SignerException in case initialization fails
+     * @deprecated Use {@link #NeptuneApacheHttpSigV4Signer(String, AwsCredentialsProvider)} instead.
+     *             SDK v1 support will be removed in a future major version.
      */
+    @Deprecated
     public NeptuneApacheHttpSigV4Signer(final String regionName,
                                         final AWSCredentialsProvider v1AwsCredentialProvider)
             throws NeptuneSigV4SignerException {
@@ -77,7 +80,10 @@ public class NeptuneApacheHttpSigV4Signer extends NeptuneSigV4SignerBase<HttpUri
      * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
      * @param serviceName            name of the service name used to sign the requests. Defaults to neptune-db
      * @throws NeptuneSigV4SignerException in case initialization fails
+     * @deprecated Use {@link #NeptuneApacheHttpSigV4Signer(String, AwsCredentialsProvider, String)} instead.
+     *             SDK v1 support will be removed in a future major version.
      */
+    @Deprecated
     public NeptuneApacheHttpSigV4Signer(final String regionName,
                                         final AWSCredentialsProvider v1AwsCredentialProvider,
                                         final String serviceName) throws NeptuneSigV4SignerException {

--- a/src/main/java/com/amazonaws/neptune/auth/NeptuneNettyHttpSigV4Signer.java
+++ b/src/main/java/com/amazonaws/neptune/auth/NeptuneNettyHttpSigV4Signer.java
@@ -51,7 +51,10 @@ public class NeptuneNettyHttpSigV4Signer extends NeptuneSigV4SignerBase<FullHttp
      * @param regionName             name of the region for which the request is signed
      * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
      * @throws NeptuneSigV4SignerException in case initialization fails
+     * @deprecated Use {@link #NeptuneNettyHttpSigV4Signer(String, AwsCredentialsProvider)} instead.
+     *             SDK v1 support will be removed in a future major version.
      */
+    @Deprecated
     public NeptuneNettyHttpSigV4Signer(final String regionName,
                                        final AWSCredentialsProvider v1AwsCredentialProvider) throws NeptuneSigV4SignerException {
         super(regionName, v1AwsCredentialProvider);
@@ -64,7 +67,10 @@ public class NeptuneNettyHttpSigV4Signer extends NeptuneSigV4SignerBase<FullHttp
      * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
      * @param serviceName            name of the service name used to sign the requests. Defaults to neptune-db
      * @throws NeptuneSigV4SignerException in case initialization fails
+     * @deprecated Use {@link #NeptuneNettyHttpSigV4Signer(String, AwsCredentialsProvider, String)} instead.
+     *             SDK v1 support will be removed in a future major version.
      */
+    @Deprecated
     public NeptuneNettyHttpSigV4Signer(final String regionName,
                                        final AWSCredentialsProvider v1AwsCredentialProvider,
                                        final String serviceName) throws NeptuneSigV4SignerException {

--- a/src/main/java/com/amazonaws/neptune/auth/NeptuneRequestMetadataSigV4Signer.java
+++ b/src/main/java/com/amazonaws/neptune/auth/NeptuneRequestMetadataSigV4Signer.java
@@ -56,7 +56,10 @@ public class NeptuneRequestMetadataSigV4Signer extends NeptuneSigV4SignerBase<Re
      * @param regionName             name of the region for which the request is signed
      * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
      * @throws NeptuneSigV4SignerException in case initialization fails
+     * @deprecated Use {@link #NeptuneRequestMetadataSigV4Signer(String, AwsCredentialsProvider)} instead.
+     *             SDK v1 support will be removed in a future major version.
      */
+    @Deprecated
     public NeptuneRequestMetadataSigV4Signer(final String regionName,
                                              final AWSCredentialsProvider v1AwsCredentialProvider) throws NeptuneSigV4SignerException {
         super(regionName, v1AwsCredentialProvider);
@@ -69,7 +72,10 @@ public class NeptuneRequestMetadataSigV4Signer extends NeptuneSigV4SignerBase<Re
      * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
      * @param serviceName            name of the service name used to sign the requests. Defaults to neptune-db
      * @throws NeptuneSigV4SignerException in case initialization fails
+     * @deprecated Use {@link #NeptuneRequestMetadataSigV4Signer(String, AwsCredentialsProvider, String)} instead.
+     *             SDK v1 support will be removed in a future major version.
      */
+    @Deprecated
     public NeptuneRequestMetadataSigV4Signer(final String regionName,
                                              final AWSCredentialsProvider v1AwsCredentialProvider,
                                              final String serviceName) throws NeptuneSigV4SignerException {

--- a/src/main/java/com/amazonaws/neptune/auth/NeptuneSigV4SignerBase.java
+++ b/src/main/java/com/amazonaws/neptune/auth/NeptuneSigV4SignerBase.java
@@ -90,7 +90,10 @@ public abstract class NeptuneSigV4SignerBase<T> implements NeptuneSigV4Signer<T>
      * @param regionName name of the region for which the request is signed
      * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
      * @throws NeptuneSigV4SignerException in case initialization fails
+     * @deprecated Use {@link #NeptuneSigV4SignerBase(String, AwsCredentialsProvider)} instead.
+     *             SDK v1 support will be removed in a future major version.
      */
+    @Deprecated
     public NeptuneSigV4SignerBase(final String regionName,
                                   final AWSCredentialsProvider v1AwsCredentialProvider) throws NeptuneSigV4SignerException {
         // Use neptune-db as default service name
@@ -104,7 +107,10 @@ public abstract class NeptuneSigV4SignerBase<T> implements NeptuneSigV4Signer<T>
      * @param v1AwsCredentialProvider the provider offering access to the credentials used for signing the request
      * @param serviceName name of the service name used to sign the requests. Defaults to neptune-db
      * @throws NeptuneSigV4SignerException in case initialization fails
+     * @deprecated Use {@link #NeptuneSigV4SignerBase(String, AwsCredentialsProvider, String)} instead.
+     *             SDK v1 support will be removed in a future major version.
      */
+    @Deprecated
     public NeptuneSigV4SignerBase(final String regionName,
                                   final AWSCredentialsProvider v1AwsCredentialProvider,
                                   final String serviceName) throws NeptuneSigV4SignerException {

--- a/src/main/java/com/amazonaws/neptune/auth/credentials/V1toV2CredentialsProvider.java
+++ b/src/main/java/com/amazonaws/neptune/auth/credentials/V1toV2CredentialsProvider.java
@@ -10,6 +10,15 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
+/**
+ * Adapter that wraps an AWS SDK v1 {@link AWSCredentialsProvider} as an SDK v2
+ * {@link AwsCredentialsProvider}.
+ *
+ * @deprecated Migrate to SDK v2 credentials directly (e.g.
+ *             {@link software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider}).
+ *             This class will be removed in a future major version.
+ */
+@Deprecated
 public class V1toV2CredentialsProvider implements AwsCredentialsProvider {
     private final AWSCredentialsProvider v1CredentialsProvider;
 


### PR DESCRIPTION
Make v1 optional dependency, bump to 4.1.0-SNAPSHOT #28

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
