### PR TITLE
Add NeptuneJavaHttpSigV4Signer for java.net.http.HttpRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,33 @@ A library for sending AWS Signature Version 4 signed requests over HTTP to [Amaz
 
 1. [NeptuneApacheHttpSigV4Signer.java](https://github.com/aws/amazon-neptune-sigv4-signer/blob/master/src/main/java/com/amazonaws/neptune/auth/NeptuneApacheHttpSigV4Signer.java) - provides an implementation for signing Apache Http Requests.
 2. [NeptuneNettyHttpSigV4Signer.java](https://github.com/aws/amazon-neptune-sigv4-signer/blob/master/src/main/java/com/amazonaws/neptune/auth/NeptuneNettyHttpSigV4Signer.java) - provides an implementation for signing Netty Http requests
-3. [NeptuneRequestMetadataSigV4Signer.java](https://github.com/aws/amazon-neptune-sigv4-signer/blob/master/src/main/java/com/amazonaws/neptune/auth/NeptuneRequestMetadataSigV4Signer.java) - provides an implementation for a generic Request object RequestMetadata. A user of this class can convert their native HttpRequest into a RequestMetadata object and pass it to this class to create the signature.
+3. [NeptuneJavaHttpSigV4Signer.java](https://github.com/aws/amazon-neptune-sigv4-signer/blob/master/src/main/java/com/amazonaws/neptune/auth/NeptuneJavaHttpSigV4Signer.java) - provides an implementation for signing `java.net.http.HttpRequest` requests (the standard Java HTTP client)
+4. [NeptuneRequestMetadataSigV4Signer.java](https://github.com/aws/amazon-neptune-sigv4-signer/blob/master/src/main/java/com/amazonaws/neptune/auth/NeptuneRequestMetadataSigV4Signer.java) - provides an implementation for a generic Request object RequestMetadata. A user of this class can convert their native HttpRequest into a RequestMetadata object and pass it to this class to create the signature.
 
 ## Usage
 
-Version 5.0.0 of this library requires **AWS SDK for Java v2** credentials. Use any `AwsCredentialsProvider` implementation from the SDK v2 `auth` module.
+This library requires **AWS SDK for Java v2** credentials. Use any `AwsCredentialsProvider` implementation from the SDK v2 `auth` module.
 
 ```java
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import com.amazonaws.neptune.auth.NeptuneNettyHttpSigV4Signer;
+import com.amazonaws.neptune.auth.NeptuneJavaHttpSigV4Signer;
 
-NeptuneNettyHttpSigV4Signer signer = new NeptuneNettyHttpSigV4Signer(
+// Create the signer
+NeptuneJavaHttpSigV4Signer signer = new NeptuneJavaHttpSigV4Signer(
     "us-east-1",
     DefaultCredentialsProvider.create());
+
+// Sign a java.net.http request
+HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+    .uri(URI.create("https://your-neptune-endpoint:8182/sparql?query=..."))
+    .GET();
+
+signer.signRequest(requestBuilder);
+HttpRequest signedRequest = requestBuilder.build();
 ```
+
+> **Note:** The JVM restricts setting the `Host` header by default. If needed, launch with
+> `-Djdk.httpclient.allowRestrictedHeaders=host`.
 
 ## Usage Examples
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,19 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+                <configuration>
+                    <argLine>-Djdk.httpclient.allowRestrictedHeaders=host</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>release</id>

--- a/src/main/java/com/amazonaws/neptune/auth/NeptuneJavaHttpSigV4Signer.java
+++ b/src/main/java/com/amazonaws/neptune/auth/NeptuneJavaHttpSigV4Signer.java
@@ -1,0 +1,200 @@
+/*
+ *   Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazonaws.neptune.auth;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.AUTHORIZATION;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.HOST;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_DATE;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_SECURITY_TOKEN;
+
+/**
+ * Signer for HTTP requests made via {@code java.net.http} {@link HttpRequest}s.
+ * <p>
+ * This signer operates on {@link HttpRequest.Builder} instances. After calling
+ * {@link #signRequest(HttpRequest.Builder)}, the builder will have the necessary
+ * SigV4 authentication headers attached. Call {@code builder.build()} to obtain
+ * the signed {@link HttpRequest}.
+ * <p>
+ * <b>Important:</b> The JVM restricts setting the {@code Host} header on
+ * {@code java.net.http.HttpRequest} by default. If you need to set it explicitly,
+ * launch the JVM with {@code -Djdk.httpclient.allowRestrictedHeaders=host}.
+ */
+public class NeptuneJavaHttpSigV4Signer extends NeptuneSigV4SignerBase<HttpRequest.Builder> {
+
+    /**
+     * Create a V4 Signer for {@code java.net.http} HTTP requests.
+     *
+     * @param regionName             name of the region for which the request is signed
+     * @param awsCredentialsProvider the provider offering access to the credentials used for signing the request
+     * @throws NeptuneSigV4SignerException in case initialization fails
+     */
+    public NeptuneJavaHttpSigV4Signer(final String regionName,
+                                      final AwsCredentialsProvider awsCredentialsProvider)
+            throws NeptuneSigV4SignerException {
+        super(regionName, awsCredentialsProvider);
+    }
+
+    /**
+     * Create a V4 Signer for {@code java.net.http} HTTP requests.
+     *
+     * @param regionName             name of the region for which the request is signed
+     * @param awsCredentialsProvider the provider offering access to the credentials used for signing the request
+     * @param serviceName            name of the service name used to sign the requests
+     * @throws NeptuneSigV4SignerException in case initialization fails
+     */
+    public NeptuneJavaHttpSigV4Signer(final String regionName,
+                                      final AwsCredentialsProvider awsCredentialsProvider,
+                                      final String serviceName)
+            throws NeptuneSigV4SignerException {
+        super(regionName, awsCredentialsProvider, serviceName);
+    }
+
+    @Override
+    protected SdkHttpFullRequest toSignableRequest(final HttpRequest.Builder requestBuilder)
+            throws NeptuneSigV4SignerException {
+
+        final HttpRequest request = requestBuilder.build();
+
+        checkNotNull(request, "The request must not be null");
+        checkNotNull(request.uri(), "The request URI must not be null");
+        checkNotNull(request.method(), "The request method must not be null");
+
+        // Convert headers, skipping Host (the signer adds it)
+        final Map<String, List<String>> headersInternal = new HashMap<>();
+        for (final Map.Entry<String, List<String>> entry : request.headers().map().entrySet()) {
+            if (!entry.getKey().equalsIgnoreCase(HOST)) {
+                headersInternal.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        // Extract query parameters
+        final URI uri = request.uri();
+        final Map<String, List<String>> parametersInternal = extractParametersFromQueryString(uri.getRawQuery());
+
+        // Extract body content
+        final InputStream content;
+        if (request.bodyPublisher().isPresent()) {
+            content = new ByteArrayInputStream(collectBodyBytes(request.bodyPublisher().get()));
+        } else {
+            content = new ByteArrayInputStream(new byte[0]);
+        }
+
+        // Build endpoint URI
+        if (uri.getHost() == null) {
+            throw new NeptuneSigV4SignerException(
+                    "Unable to extract host information from the request URI, required for SigV4 signing: " + uri);
+        }
+        final URI endpoint = URI.create(uri.getScheme() + "://" + uri.getAuthority());
+
+        return convertToSignableRequest(
+                request.method(),
+                endpoint,
+                uri.getPath(),
+                headersInternal,
+                parametersInternal,
+                content);
+    }
+
+    @Override
+    protected void attachSignature(final HttpRequest.Builder request, final NeptuneSigV4Signature signature)
+            throws NeptuneSigV4SignerException {
+
+        checkNotNull(signature, "The signature must not be null");
+        checkNotNull(signature.getHostHeader(), "The signed Host header must not be null");
+        checkNotNull(signature.getXAmzDateHeader(), "The signed X-AMZ-DATE header must not be null");
+        checkNotNull(signature.getAuthorizationHeader(), "The signed Authorization header must not be null");
+
+        request.setHeader(HOST, signature.getHostHeader());
+        request.setHeader(X_AMZ_DATE, signature.getXAmzDateHeader());
+        request.setHeader(AUTHORIZATION, signature.getAuthorizationHeader());
+
+        if (!signature.getSessionToken().isEmpty()) {
+            request.setHeader(X_AMZ_SECURITY_TOKEN, signature.getSessionToken());
+        }
+    }
+
+    /**
+     * Collects all bytes from a {@link HttpRequest.BodyPublisher} synchronously.
+     * This works correctly for standard body publishers (ofString, ofByteArray, ofInputStream)
+     * which publish their content immediately upon subscription.
+     */
+    private static byte[] collectBodyBytes(final HttpRequest.BodyPublisher publisher) throws NeptuneSigV4SignerException {
+        final List<ByteBuffer> buffers = new ArrayList<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Throwable[] error = new Throwable[1];
+
+        publisher.subscribe(new Flow.Subscriber<>() {
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(ByteBuffer item) {
+                byte[] bytes = new byte[item.remaining()];
+                item.get(bytes);
+                buffers.add(ByteBuffer.wrap(bytes));
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                error[0] = throwable;
+                latch.countDown();
+            }
+
+            @Override
+            public void onComplete() {
+                latch.countDown();
+            }
+        });
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new NeptuneSigV4SignerException("Interrupted while reading request body", e);
+        }
+
+        if (error[0] != null) {
+            throw new NeptuneSigV4SignerException("Error reading request body", error[0]);
+        }
+
+        int totalSize = buffers.stream().mapToInt(ByteBuffer::remaining).sum();
+        byte[] result = new byte[totalSize];
+        int offset = 0;
+        for (ByteBuffer buf : buffers) {
+            int len = buf.remaining();
+            buf.get(result, offset, len);
+            offset += len;
+        }
+        return result;
+    }
+}

--- a/src/test/java/com/amazonaws/neptune/auth/NeptuneJavaHttpSigV4SignerTest.java
+++ b/src/test/java/com/amazonaws/neptune/auth/NeptuneJavaHttpSigV4SignerTest.java
@@ -1,0 +1,85 @@
+/*
+ *   Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazonaws.neptune.auth;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class NeptuneJavaHttpSigV4SignerTest extends NeptuneSigV4SignerAbstractTest<HttpRequest.Builder> {
+
+    private final NeptuneJavaHttpSigV4Signer signer;
+
+    public NeptuneJavaHttpSigV4SignerTest() throws NeptuneSigV4SignerException {
+        this.signer = new NeptuneJavaHttpSigV4Signer(TEST_REGION, awsCredentialsProvider);
+    }
+
+    @Override
+    protected NeptuneSigV4SignerBase<HttpRequest.Builder> getSigner() {
+        return signer;
+    }
+
+    @Override
+    protected HttpRequest.Builder createGetRequest(final String fullURI, final Map<String, String> expectedHeaders) {
+        final HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .GET()
+                .version(HttpClient.Version.HTTP_1_1)
+                .uri(URI.create(fullURI));
+        expectedHeaders.forEach(builder::header);
+        return builder;
+    }
+
+    @Override
+    protected HttpRequest.Builder createPostRequest(final String fullURI,
+                                                    final Map<String, String> expectedHeaders,
+                                                    final String payload) {
+        final HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .POST(HttpRequest.BodyPublishers.ofByteArray(payload.getBytes(StandardCharsets.UTF_8)))
+                .version(HttpClient.Version.HTTP_1_1)
+                .uri(URI.create(fullURI));
+        expectedHeaders.forEach(builder::header);
+        return builder;
+    }
+
+    @Override
+    protected Map<String, String> getRequestHeaders(final HttpRequest.Builder requestBuilder) {
+        final Map<String, String> headers = new HashMap<>();
+        requestBuilder.build().headers().map().forEach((k, v) -> headers.put(k, v.get(0)));
+        return headers;
+    }
+
+    /**
+     * Override: java.net.http validates URIs eagerly — a relative path without host
+     * throws IllegalArgumentException at URI.create() time, not during signing.
+     */
+    @Override
+    public void toSignableRequestGetNoHost() throws NeptuneSigV4SignerException {
+        final String uri = TEST_REQUEST_PATH;
+        final Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put(HEADER_ONE_NAME, HEADER_ONE_VALUE);
+        requestHeaders.put(HEADER_TWO_NAME, HEADER_TWO_VALUE);
+
+        try {
+            final HttpRequest.Builder request = createGetRequest(uri, requestHeaders);
+            signer.toSignableRequest(request);
+        } catch (IllegalArgumentException e) {
+            throw new NeptuneSigV4SignerException("URI validation failed", e);
+        }
+    }
+}


### PR DESCRIPTION
Implements a SigV4 signer for the standard Java HTTP client (java.net.http), addressing issue #21. This enables signing HttpRequest objects without requiring Apache HttpClient or Netty dependencies.

- New NeptuneJavaHttpSigV4Signer extends NeptuneSigV4SignerBase<HttpRequest.Builder>
- Uses CountDownLatch + Flow.Subscriber for safe synchronous body extraction
- Full test coverage via NeptuneSigV4SignerAbstractTest
- Added surefire config for -Djdk.httpclient.allowRestrictedHeaders=host
- Updated README with new signer and usage example

Closes #21

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
